### PR TITLE
PKG-13155: update markitdown to 0.1.5

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -1,0 +1,4 @@
+anaconda_config_version: 1
+upstream_sources:
+  - pypi:
+      identifier: markitdown

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "markitdown" %}
-{% set version = "0.1.1" %}
+{% set version = "0.1.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: da97a55a45a3d775ea758e88a344d5cac94ee97115fb0293f99027d32c2fc3f6
+  sha256: 4c956ff1528bf15e1814542035ec96e989206d19d311bb799f4df973ecafc31a
 
 build:
   number: 0
@@ -29,6 +29,7 @@ requirements:
     - markdownify
     - magika >=0.6.1,<0.7.dev0
     - charset-normalizer
+    - defusedxml
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true  # [py<310 or py>313]  # magika has no py314 build (needs onnxruntime py314)
+  skip: true  # [py<310]
   python:
     entry_points:
       - markitdown = markitdown.__main__:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,10 +12,10 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true  # [py<310]
-  python:
-    entry_points:
-      - markitdown = markitdown.__main__:main
+  # magika dep has no py314 build; numpy/mkl/onnxruntime cyclic dep on win py3.10
+  skip: true  # [py<310 or py>313 or (win and py==310)]
+  entry_points:
+    - markitdown = markitdown.__main__:main
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true  # [py<310]
+  skip: true  # [py<310 or py>313]  # magika has no py314 build (needs onnxruntime py314)
   python:
     entry_points:
       - markitdown = markitdown.__main__:main


### PR DESCRIPTION
markitdown 0.1.5

**Destination channel:** defaults

### Links

- [PKG-13155](https://anaconda.atlassian.net/browse/PKG-13155)
- [Upstream repository](https://github.com/microsoft/markitdown)
- [Upstream changelog/diff](https://github.com/microsoft/markitdown/compare/v0.1.1...v0.1.5)

### Explanation of changes:

- Update markitdown from 0.1.1 to 0.1.5
- Pure Python package, build system unchanged (hatchling)
- Added new core dep: `defusedxml` (available in pkgs/main)
- Other run deps unchanged

[PKG-13155]: https://anaconda.atlassian.net/browse/PKG-13155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ