### PR TITLE
Update version to 0.1.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "markitdown" %}
-{% set version = "0.1.1" %}
+{% set version = "0.1.5" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: da97a55a45a3d775ea758e88a344d5cac94ee97115fb0293f99027d32c2fc3f6
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 4c956ff1528bf15e1814542035ec96e989206d19d311bb799f4df973ecafc31a
 
 build:
   number: 0
@@ -29,6 +29,7 @@ requirements:
     - markdownify
     - magika >=0.6.1,<0.7.dev0
     - charset-normalizer
+    - defusedxml
 
 test:
   imports:


### PR DESCRIPTION
markitdown 0.1.5

**Destination channel:**  defaults

### Links

- [PKG-13155](https://anaconda.atlassian.net/browse/PKG-13155) 
- [Upstream repository](https://github.com/microsoft/markitdown)

### Explanation of changes:
- New version number
- Updated requirements


[PKG-13155]: https://anaconda.atlassian.net/browse/PKG-13155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ